### PR TITLE
gcp - add load balancing service initial setup

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/entry.py
+++ b/tools/c7n_gcp/c7n_gcp/entry.py
@@ -30,7 +30,8 @@ import c7n_gcp.resources.resourcemanager
 import c7n_gcp.resources.service
 import c7n_gcp.resources.source
 import c7n_gcp.resources.storage
-import c7n_gcp.resources.sql  # noqa: F401
+import c7n_gcp.resources.sql
+import c7n_gcp.resources.loadbalancing  # noqa: F401
 
 from c7n_gcp.provider import resources as gcp_resources
 

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -178,3 +178,21 @@ class LoadBalancingHttpsHealthCheck(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'httpsHealthCheck': resource_info['name']})
+
+
+@resources.register('loadbalancing-http-health-check')
+class LoadBalancingHttpHealthCheck(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'httpHealthChecks'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'httpHealthCheck': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -88,3 +88,21 @@ class LoadBalancingTargetSslProxy(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'targetSslProxy': resource_info['name']})
+
+
+@resources.register('loadbalancing-ssl-policy')
+class LoadBalancingSslPolicy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'sslPolicies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'sslPolicy': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -142,3 +142,21 @@ class LoadBalancingTargetHttpsProxy(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'targetHttpsProxy': resource_info['name']})
+
+
+@resources.register('loadbalancing-backend-bucket')
+class LoadBalancingBackendBucket(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'backendBuckets'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'backendBucket': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -225,9 +225,28 @@ class LoadBalancingTargetHttpProxy(QueryResourceManager):
         component = 'targetHttpProxies'
         enum_spec = ('list', 'items[]', None)
         scope = 'project'
+        id = 'name'
 
         @staticmethod
         def get(client, resource_info):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'targetHttpProxy': resource_info['name']})
+
+
+@resources.register('loadbalancing-backend-service')
+class LoadBalancingBackendService(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'backendServices'
+        enum_spec = ('aggregatedList', 'items.*.backendServices[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'backendService': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -31,3 +31,19 @@ class LoadBalancingAddress(QueryResourceManager):
         @staticmethod
         def get(client, resource_info):
             return client.execute_command('get', resource_info)
+
+
+@resources.register('loadbalancing-url-map')
+class LoadBalancingUrlMap(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'urlMaps'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -106,3 +106,39 @@ class LoadBalancingSslPolicy(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'sslPolicy': resource_info['name']})
+
+
+@resources.register('loadbalancing-ssl-certificate')
+class LoadBalancingSslCertificate(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'sslCertificates'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'sslCertificate': resource_info['name']})
+
+
+@resources.register('loadbalancing-target-https-proxy')
+class LoadBalancingTargetHttpsProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetHttpsProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetHttpsProxy': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -196,3 +196,21 @@ class LoadBalancingHttpHealthCheck(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'httpHealthCheck': resource_info['name']})
+
+
+@resources.register('loadbalancing-health-check')
+class LoadBalancingHealthCheck(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'healthChecks'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'healthCheck': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -288,3 +288,22 @@ class LoadBalancingTargetPool(QueryResourceManager):
                 'project': resource_info['project_id'],
                 'region': resource_info['region'].rsplit('/', 1)[-1],
                 'targetPool': resource_info['name']})
+
+
+@resources.register('loadbalancing-forwarding-rule')
+class LoadBalancingForwardingRule(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'forwardingRules'
+        enum_spec = ('aggregatedList', 'items.*.forwardingRules[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'region': resource_info['region'].rsplit('/', 1)[-1],
+                'forwardingRule': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -58,6 +58,23 @@ class LoadBalancingTargetTcpProxy(QueryResourceManager):
         component = 'targetTcpProxies'
         enum_spec = ('list', 'items[]', None)
         scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)
+
+
+@resources.register('loadbalancing-target-ssl-proxy')
+class LoadBalancingTargetSslProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetSslProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
 
         @staticmethod
         def get(client, resource_info):

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -214,3 +214,20 @@ class LoadBalancingHealthCheck(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'healthCheck': resource_info['name']})
+
+
+@resources.register('loadbalancing-target-http-proxy')
+class LoadBalancingTargetHttpProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetHttpProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetHttpProxy': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -250,3 +250,23 @@ class LoadBalancingBackendService(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'backendService': resource_info['name']})
+
+
+@resources.register('loadbalancing-target-instance')
+class LoadBalancingTargetInstance(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetInstances'
+        enum_spec = ('aggregatedList', 'items.*.targetInstances[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'zone': resource_info['zone'].rsplit('/', 1)[-1],
+                'targetInstance': resource_info['name']})
+

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -307,3 +307,21 @@ class LoadBalancingForwardingRule(QueryResourceManager):
                 'project': resource_info['project_id'],
                 'region': resource_info['region'].rsplit('/', 1)[-1],
                 'forwardingRule': resource_info['name']})
+
+
+@resources.register('loadbalancing-global-forwarding-rule')
+class LoadBalancingGlobalForwardingRule(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'globalForwardingRules'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'forwardingRule': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -47,3 +47,18 @@ class LoadBalancingUrlMap(QueryResourceManager):
         @staticmethod
         def get(client, resource_info):
             return client.execute_command('get', resource_info)
+
+
+@resources.register('loadbalancing-target-tcp-proxy')
+class LoadBalancingTargetTcpProxy(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetTcpProxies'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -160,3 +160,21 @@ class LoadBalancingBackendBucket(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'backendBucket': resource_info['name']})
+
+
+@resources.register('loadbalancing-https-health-check')
+class LoadBalancingHttpsHealthCheck(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'httpsHealthChecks'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'httpsHealthCheck': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -1,0 +1,33 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from c7n_gcp.provider import resources
+from c7n_gcp.query import QueryResourceManager, TypeInfo
+
+
+@resources.register('loadbalancing-address')
+class LoadBalancingAddress(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'addresses'
+        enum_spec = ('aggregatedList', 'items.*.addresses[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', resource_info)

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -270,3 +270,21 @@ class LoadBalancingTargetInstance(QueryResourceManager):
                 'zone': resource_info['zone'].rsplit('/', 1)[-1],
                 'targetInstance': resource_info['name']})
 
+
+@resources.register('loadbalancing-target-pool')
+class LoadBalancingTargetPool(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'targetPools'
+        enum_spec = ('aggregatedList', 'items.*.targetPools[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'region': resource_info['region'].rsplit('/', 1)[-1],
+                'targetPool': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -30,7 +30,10 @@ class LoadBalancingAddress(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'region': resource_info['region'],
+                'address': resource_info['name']})
 
 
 @resources.register('loadbalancing-url-map')
@@ -46,7 +49,9 @@ class LoadBalancingUrlMap(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'urlMap': resource_info['name']})
 
 
 @resources.register('loadbalancing-target-tcp-proxy')
@@ -62,7 +67,9 @@ class LoadBalancingTargetTcpProxy(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetTcpProxy': resource_info['name']})
 
 
 @resources.register('loadbalancing-target-ssl-proxy')
@@ -78,4 +85,6 @@ class LoadBalancingTargetSslProxy(QueryResourceManager):
 
         @staticmethod
         def get(client, resource_info):
-            return client.execute_command('get', resource_info)
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'targetSslProxy': resource_info['name']})

--- a/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/loadbalancing.py
@@ -325,3 +325,21 @@ class LoadBalancingGlobalForwardingRule(QueryResourceManager):
             return client.execute_command('get', {
                 'project': resource_info['project_id'],
                 'forwardingRule': resource_info['name']})
+
+
+@resources.register('loadbalancing-global-address')
+class LoadBalancingGlobalAddress(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'compute'
+        version = 'v1'
+        component = 'globalAddresses'
+        enum_spec = ('list', 'items[]', None)
+        scope = 'project'
+        id = 'name'
+
+        @staticmethod
+        def get(client, resource_info):
+            return client.execute_command('get', {
+                'project': resource_info['project_id'],
+                'address': resource_info['name']})

--- a/tools/c7n_gcp/tests/data/flights/lb-addresses-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-addresses-new1_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-addresses-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-addresses-new1_1.json
@@ -1,0 +1,32 @@
+{
+  "headers": {
+    "expires": "Tue, 05 Mar 2019 10:26:16 GMT",
+    "date": "Tue, 05 Mar 2019 10:26:16 GMT",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "etag": "\"AIRMFkoY8YjJYfvNisNXJV7nEnQ=/u0DnQFqBn2MpIu85qWIblb-lPs0=\"",
+    "vary": "Origin, X-Origin",
+    "content-type": "application/json; charset=UTF-8",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-xss-protection": "1; mode=block",
+    "server": "GSE",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "450",
+    "-content-encoding": "gzip",
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/addresses/new1?alt=json"
+  },
+  "body": {
+    "kind": "compute#address",
+    "id": "8149548791059677337",
+    "creationTimestamp": "2019-03-05T01:16:38.474-08:00",
+    "name": "new1",
+    "description": "",
+    "address": "35.193.10.19",
+    "status": "RESERVED",
+    "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/dcloud-custodian/regions/us-central1/addresses/new1",
+    "networkTier": "PREMIUM"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-addresses-query/get-compute-v1-projects-cloud-custodian-aggregated-addresses_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-addresses-query/get-compute-v1-projects-cloud-custodian-aggregated-addresses_1.json
@@ -1,0 +1,259 @@
+{
+  "headers": {
+    "expires": "Tue, 05 Mar 2019 09:27:05 GMT",
+    "date": "Tue, 05 Mar 2019 09:27:05 GMT",
+    "cache-control": "private, max-age=0, must-revalidate, no-transform",
+    "etag": "\"rYPkhItTdpx_do5KgRCVkj15NeA=/RgOQS9vmqswMCiZmWLzM07OCRiM=\"",
+    "vary": "Origin, X-Origin",
+    "content-type": "application/json; charset=UTF-8",
+    "x-content-type-options": "nosniff",
+    "x-frame-options": "SAMEORIGIN",
+    "x-xss-protection": "1; mode=block",
+    "server": "GSE",
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"",
+    "transfer-encoding": "chunked",
+    "status": "200",
+    "content-length": "5592",
+    "-content-encoding": "gzip",
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/addresses?alt=json"
+  },
+  "body": {
+    "kind": "compute#addressAggregatedList",
+    "id": "projects/cloud-custodian/aggregated/addresses",
+    "items": {
+      "global": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'global' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "global"
+            }
+          ]
+        }
+      },
+      "regions/us-central1": {
+        "addresses": [
+          {
+            "kind": "compute#address",
+            "id": "8149548791059677337",
+            "creationTimestamp": "2019-03-05T01:16:38.474-08:00",
+            "name": "new1",
+            "description": "",
+            "address": "35.193.10.19",
+            "status": "RESERVED",
+            "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1",
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/addresses/new1",
+            "networkTier": "PREMIUM"
+          }
+        ]
+      },
+      "regions/europe-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west1"
+            }
+          ]
+        }
+      },
+      "regions/us-west1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-west1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west1"
+            }
+          ]
+        }
+      },
+      "regions/asia-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-east1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-east1"
+            }
+          ]
+        }
+      },
+      "regions/us-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-east1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east1"
+            }
+          ]
+        }
+      },
+      "regions/asia-northeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-northeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-northeast1"
+            }
+          ]
+        }
+      },
+      "regions/asia-southeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-southeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-southeast1"
+            }
+          ]
+        }
+      },
+      "regions/us-east4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-east4' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-east4"
+            }
+          ]
+        }
+      },
+      "regions/australia-southeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/australia-southeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/australia-southeast1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west2' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west2"
+            }
+          ]
+        }
+      },
+      "regions/europe-west3": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west3' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west3"
+            }
+          ]
+        }
+      },
+      "regions/southamerica-east1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/southamerica-east1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/southamerica-east1"
+            }
+          ]
+        }
+      },
+      "regions/asia-south1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-south1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-south1"
+            }
+          ]
+        }
+      },
+      "regions/northamerica-northeast1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/northamerica-northeast1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/northamerica-northeast1"
+            }
+          ]
+        }
+      },
+      "regions/europe-west4": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-west4' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-west4"
+            }
+          ]
+        }
+      },
+      "regions/europe-north1": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/europe-north1' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/europe-north1"
+            }
+          ]
+        }
+      },
+      "regions/us-west2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/us-west2' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/us-west2"
+            }
+          ]
+        }
+      },
+      "regions/asia-east2": {
+        "warning": {
+          "code": "NO_RESULTS_ON_PAGE",
+          "message": "There are no results for scope 'regions/asia-east2' on this page.",
+          "data": [
+            {
+              "key": "scope",
+              "value": "regions/asia-east2"
+            }
+          ]
+        }
+      }
+    },
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/decoded-pier-228312/aggregated/addresses"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-get/get-compute-v1-projects-cloud-custodian-global-backendBuckets-newbucket_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-get/get-compute-v1-projects-cloud-custodian-global-backendBuckets-newbucket_1.json
@@ -1,0 +1,30 @@
+{
+  "body": {
+    "kind": "compute#backendBucket", 
+    "description": "", 
+    "enableCdn": false, 
+    "bucketName": "newbucket_em", 
+    "creationTimestamp": "2019-03-12T02:55:51.212-07:00", 
+    "id": "1200379941928713416", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket", 
+    "name": "newbucket"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "331", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 13 Mar 2019 17:39:45 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 13 Mar 2019 17:39:45 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"jcSou3GFDYsczJSpiYniFcvc0bc=/r6goSRbOgpOAvxsuPDb35JNsG0o=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-query/get-compute-v1-projects-cloud-custodian-global-backendBuckets_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-backend-buckets-query/get-compute-v1-projects-cloud-custodian-global-backendBuckets_1.json
@@ -1,0 +1,37 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#backendBucket", 
+        "description": "", 
+        "enableCdn": false, 
+        "bucketName": "newbucket_em", 
+        "creationTimestamp": "2019-03-12T02:55:51.212-07:00", 
+        "id": "1200379941928713416", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket", 
+        "name": "newbucket"
+      }
+    ], 
+    "kind": "compute#backendBucketList", 
+    "id": "projects/cloud-custodian/global/backendBuckets", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "574", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 13 Mar 2019 17:37:05 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 13 Mar 2019 17:37:05 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"Vigi4KrCJsAk6dAcCrpUcsJTBw8=/4_bmPo5kV8sGBzCB9oBsXFGv9fE=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-backend-services-get/get-compute-v1-projects-cloud-custodian-global-backendServices-new-backend-service_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-backend-services-get/get-compute-v1-projects-cloud-custodian-global-backendServices-new-backend-service_1.json
@@ -1,0 +1,43 @@
+{
+  "body": {
+    "connectionDraining": {
+      "drainingTimeoutSec": 0
+    }, 
+    "kind": "compute#backendService", 
+    "protocol": "HTTP", 
+    "description": "", 
+    "timeoutSec": 30, 
+    "enableCDN": false, 
+    "affinityCookieTtlSec": 0, 
+    "port": 80, 
+    "loadBalancingScheme": "EXTERNAL", 
+    "fingerprint": "oERaOPFx36Q=", 
+    "portName": "http", 
+    "healthChecks": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-http-health-check"
+    ], 
+    "sessionAffinity": "NONE", 
+    "creationTimestamp": "2019-03-14T03:02:45.698-07:00", 
+    "id": "3785139196791330858", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/new-backend-service", 
+    "name": "new-backend-service"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "711", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 13:12:07 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 13:12:07 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/new-backend-service?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"JtV14TmaXddmL3npemiOWNa2FGw=/82KVTRTS9uWyq2im3bww3AuIGdY=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-backend-services-query/get-compute-v1-projects-cloud-custodian-aggregated-backendServices_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-backend-services-query/get-compute-v1-projects-cloud-custodian-aggregated-backendServices_1.json
@@ -1,0 +1,282 @@
+{
+  "body": {
+    "items": {
+      "regions/us-west2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-west2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-west2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-northeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-northeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-northeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-west1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-west1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-west1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/southamerica-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/southamerica-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/southamerica-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west6": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west6' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west6", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west4": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west4' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west4", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-north1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-north1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-north1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "global": {
+        "backendServices": [
+          {
+            "connectionDraining": {
+              "drainingTimeoutSec": 0
+            }, 
+            "kind": "compute#backendService", 
+            "protocol": "HTTP", 
+            "description": "", 
+            "timeoutSec": 30, 
+            "enableCDN": false, 
+            "affinityCookieTtlSec": 0, 
+            "port": 80, 
+            "loadBalancingScheme": "EXTERNAL", 
+            "fingerprint": "oERaOPFx36Q=", 
+            "portName": "http", 
+            "healthChecks": [
+              "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-http-health-check"
+            ], 
+            "sessionAffinity": "NONE", 
+            "creationTimestamp": "2019-03-14T03:02:45.698-07:00", 
+            "id": "3785139196791330858", 
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/new-backend-service", 
+            "name": "new-backend-service"
+          }
+        ]
+      }, 
+      "regions/us-east4": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-east4' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-east4", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west3": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west3' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west3", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/australia-southeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/australia-southeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/australia-southeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-south1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-south1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-south1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-southeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-southeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-southeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-central1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-central1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-central1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-east2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-east2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-east2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/northamerica-northeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/northamerica-northeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/northamerica-northeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }
+    }, 
+    "kind": "compute#backendServiceAggregatedList", 
+    "id": "projects/cloud-custodian/aggregated/backendServices", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/backendServices"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "6216", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 13:07:18 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 13:07:18 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/backendServices?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"E0rbWnGk4_RjT8xv7AAt2wq2cWk=/kgQ72XYyNv0ADouVvEZKN1Bu8YI=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-forwarding-rules-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-forwardingRules-new-fe_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-forwarding-rules-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-forwardingRules-new-fe_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "kind": "compute#forwardingRule", 
+    "description": "", 
+    "IPAddress": "35.206.75.120", 
+    "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1", 
+    "networkTier": "STANDARD", 
+    "loadBalancingScheme": "EXTERNAL", 
+    "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-url-map-target-proxy", 
+    "portRange": "80-80", 
+    "IPProtocol": "TCP", 
+    "creationTimestamp": "2019-03-17T21:28:47.400-07:00", 
+    "id": "4700927637065998480", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/new-fe", 
+    "name": "new-fe"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "660", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 18 Mar 2019 04:44:52 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 18 Mar 2019 04:44:52 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/new-fe?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"EFIxCN-cHAhcfDlKvrp5wxk0JAI=/BEqHG7CVSEwV2KOKodEsDPxwd58=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-forwarding-rules-query/get-compute-v1-projects-cloud-custodian-aggregated-forwardingRules_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-forwarding-rules-query/get-compute-v1-projects-cloud-custodian-aggregated-forwardingRules_1.json
@@ -1,0 +1,274 @@
+{
+  "body": {
+    "items": {
+      "regions/us-west2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-west2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-west2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-northeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-northeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-northeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-west1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-west1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-west1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/southamerica-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/southamerica-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/southamerica-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west6": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west6' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west6", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west4": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west4' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west4", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-north1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-north1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-north1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "global": {
+        "warning": {
+          "message": "There are no results for scope 'global' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "global", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-east4": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-east4' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-east4", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west3": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west3' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west3", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/australia-southeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/australia-southeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/australia-southeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-south1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-south1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-south1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-southeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-southeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-southeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-central1": {
+        "forwardingRules": [
+          {
+            "kind": "compute#forwardingRule", 
+            "description": "", 
+            "IPAddress": "35.206.75.120", 
+            "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1", 
+            "networkTier": "STANDARD", 
+            "loadBalancingScheme": "EXTERNAL", 
+            "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-url-map-target-proxy", 
+            "portRange": "80-80", 
+            "IPProtocol": "TCP", 
+            "creationTimestamp": "2019-03-17T21:28:47.400-07:00", 
+            "id": "4700927637065998480", 
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/forwardingRules/new-fe", 
+            "name": "new-fe"
+          }
+        ]
+      }, 
+      "regions/asia-east2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-east2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-east2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/northamerica-northeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/northamerica-northeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/northamerica-northeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }
+    }, 
+    "kind": "compute#forwardingRuleAggregatedList", 
+    "id": "projects/cloud-custodian/aggregated/forwardingRules", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/forwardingRules"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "6107", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 18 Mar 2019 04:40:00 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 18 Mar 2019 04:40:00 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/forwardingRules?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"9GtV-Qkhy5SUlyQaQiUKJWj2dE4=/ortZHV5Czwd-xKEdW3Mv9b1ESb4=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-global-addresses-get/get-compute-v1-projects-cloud-custodian-global-addresses-new-global-address_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-global-addresses-get/get-compute-v1-projects-cloud-custodian-global-addresses-new-global-address_1.json
@@ -1,0 +1,31 @@
+{
+  "body": {
+    "status": "RESERVED", 
+    "kind": "compute#address", 
+    "description": "", 
+    "networkTier": "PREMIUM", 
+    "address": "35.241.5.194", 
+    "creationTimestamp": "2019-03-17T22:07:57.553-07:00", 
+    "id": "332437561884711234", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/new-global-address", 
+    "name": "new-global-address"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "363", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 18 Mar 2019 05:23:06 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 18 Mar 2019 05:23:06 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/new-global-address?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"6DXelrQIxiPSJ0y5BVrSLIvSPp8=/TqirRmfzM3x62dh9wGjDt_rPJOI=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-global-addresses-query/get-compute-v1-projects-cloud-custodian-global-addresses_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-global-addresses-query/get-compute-v1-projects-cloud-custodian-global-addresses_1.json
@@ -1,0 +1,38 @@
+{
+  "body": {
+    "items": [
+      {
+        "status": "RESERVED", 
+        "kind": "compute#address", 
+        "description": "", 
+        "networkTier": "PREMIUM", 
+        "address": "35.241.5.194", 
+        "creationTimestamp": "2019-03-17T22:07:57.553-07:00", 
+        "id": "332437561884711234", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses/new-global-address", 
+        "name": "new-global-address"
+      }
+    ], 
+    "kind": "compute#addressList", 
+    "id": "projects/cloud-custodian/global/addresses", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "592", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 18 Mar 2019 05:12:56 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 18 Mar 2019 05:12:56 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/addresses?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"5Ca52uZRGjEsy-3Y6oQPHbycfx4=/ku7UV0Eo6fTkj_BL5ETYTn4nllc=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-global-forwarding-rules-get/get-compute-v1-projects-cloud-custodian-global-forwardingRules-new-global-frontend_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-global-forwarding-rules-get/get-compute-v1-projects-cloud-custodian-global-forwardingRules-new-global-frontend_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "kind": "compute#forwardingRule", 
+    "description": "", 
+    "creationTimestamp": "2019-03-17T21:51:27.007-07:00", 
+    "ipVersion": "IPV4", 
+    "networkTier": "PREMIUM", 
+    "loadBalancingScheme": "EXTERNAL", 
+    "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-url-map-target-proxy-2", 
+    "portRange": "80-80", 
+    "IPProtocol": "TCP", 
+    "IPAddress": "107.178.240.215", 
+    "id": "4493655530428079392", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/new-global-frontend", 
+    "name": "new-global-frontend"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "597", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 18 Mar 2019 05:02:52 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 18 Mar 2019 05:02:52 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/new-global-frontend?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"nR8Onu3PqRAwzCgTpxQ5JCwa9Jk=/NDGaU-LRVPPnc57eHjPfnkxBrJg=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-global-forwarding-rules-query/get-compute-v1-projects-cloud-custodian-global-forwardingRules_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-global-forwarding-rules-query/get-compute-v1-projects-cloud-custodian-global-forwardingRules_1.json
@@ -1,0 +1,42 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#forwardingRule", 
+        "description": "", 
+        "creationTimestamp": "2019-03-17T21:51:27.007-07:00", 
+        "ipVersion": "IPV4", 
+        "networkTier": "PREMIUM", 
+        "loadBalancingScheme": "EXTERNAL", 
+        "target": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-url-map-target-proxy-2", 
+        "portRange": "80-80", 
+        "IPProtocol": "TCP", 
+        "IPAddress": "107.178.240.215", 
+        "id": "4493655530428079392", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules/new-global-frontend", 
+        "name": "new-global-frontend"
+      }
+    ], 
+    "kind": "compute#forwardingRuleList", 
+    "id": "projects/cloud-custodian/global/forwardingRules", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "853", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 18 Mar 2019 05:00:51 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 18 Mar 2019 05:00:51 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/forwardingRules?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"fYCNm5q9cg46LiNFvg6j3q3cmfs=/EQ5SPixyjQAfMoSivk80KqZlPCo=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-health-checks-get/get-compute-v1-projects-cloud-custodian-global-healthChecks-new-tcp-health-check_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-health-checks-get/get-compute-v1-projects-cloud-custodian-global-healthChecks-new-tcp-health-check_1.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "kind": "compute#healthCheck", 
+    "name": "new-tcp-health-check", 
+    "timeoutSec": 5, 
+    "type": "TCP", 
+    "checkIntervalSec": 5, 
+    "unhealthyThreshold": 2, 
+    "healthyThreshold": 2, 
+    "tcpHealthCheck": {
+      "proxyHeader": "NONE", 
+      "port": 80
+    }, 
+    "creationTimestamp": "2019-03-14T02:39:31.684-07:00", 
+    "id": "275508814053613500", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-tcp-health-check"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "447", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 09:48:36 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 09:48:36 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-tcp-health-check?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"7je52W_149pfYxaOG0NSQZspioo=/gSCSB42qmdNipsKa3J1G2HlhG8E=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-health-checks-query/get-compute-v1-projects-cloud-custodian-global-healthChecks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-health-checks-query/get-compute-v1-projects-cloud-custodian-global-healthChecks_1.json
@@ -1,0 +1,43 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#healthCheck", 
+        "name": "new-tcp-health-check", 
+        "timeoutSec": 5, 
+        "type": "TCP", 
+        "checkIntervalSec": 5, 
+        "unhealthyThreshold": 2, 
+        "healthyThreshold": 2, 
+        "tcpHealthCheck": {
+          "proxyHeader": "NONE", 
+          "port": 80
+        }, 
+        "creationTimestamp": "2019-03-14T02:39:31.684-07:00", 
+        "id": "275508814053613500", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks/new-tcp-health-check"
+      }
+    ], 
+    "kind": "compute#healthCheckList", 
+    "id": "projects/cloud-custodian/global/healthChecks", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "696", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 09:46:29 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 09:46:29 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/healthChecks?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"IVRGXwcz7iD8cOynpbKL98egBqk=/h96BRJCM1LT4PON7vR2yY5eMXaQ=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks-newhttphealthcheck_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks-newhttphealthcheck_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "kind": "compute#httpHealthCheck", 
+    "description": "", 
+    "timeoutSec": 5, 
+    "checkIntervalSec": 10, 
+    "port": 80, 
+    "healthyThreshold": 2, 
+    "host": "", 
+    "requestPath": "/", 
+    "unhealthyThreshold": 3, 
+    "creationTimestamp": "2019-03-14T00:45:36.570-07:00", 
+    "id": "7550768777334863951", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks/newhttphealthcheck", 
+    "name": "newhttphealthcheck"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "441", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:56:35 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:56:35 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks/newhttphealthcheck?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"UIx2Dvpqy8KrCmmYGrEZyNjt5ak=/FasiAVALgZgA4fuqwO5tLBVD-R8=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-http-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpHealthChecks_1.json
@@ -1,0 +1,42 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#httpHealthCheck", 
+        "description": "", 
+        "timeoutSec": 5, 
+        "checkIntervalSec": 10, 
+        "port": 80, 
+        "healthyThreshold": 2, 
+        "host": "", 
+        "requestPath": "/", 
+        "unhealthyThreshold": 3, 
+        "creationTimestamp": "2019-03-14T00:45:36.570-07:00", 
+        "id": "7550768777334863951", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks/newhttphealthcheck", 
+        "name": "newhttphealthcheck"
+      }
+    ], 
+    "kind": "compute#httpHealthCheckList", 
+    "id": "projects/cloud-custodian/global/httpHealthChecks", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "700", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:54:24 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:54:24 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpHealthChecks?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"Bd4cnXe-clokjVT1_aiSi9pIn-U=/iRYqB4Zldlz_brdFzsSLelqqpgA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks-newhealthcheck_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-get/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks-newhealthcheck_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "kind": "compute#httpsHealthCheck", 
+    "description": "", 
+    "timeoutSec": 5, 
+    "checkIntervalSec": 10, 
+    "port": 443, 
+    "healthyThreshold": 2, 
+    "host": "", 
+    "requestPath": "/", 
+    "unhealthyThreshold": 3, 
+    "creationTimestamp": "2019-03-13T23:57:20.595-07:00", 
+    "id": "1274526500684842431", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks/newhealthcheck", 
+    "name": "newhealthcheck"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "436", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:40:19 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:40:19 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks/newhealthcheck?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"XpxFoVv_I_4ZMZpFaSbzEEVFNFg=/bYYwIJWMM_EYA5YNMMdEoKyRgL8=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-https-health-checks-query/get-compute-v1-projects-cloud-custodian-global-httpsHealthChecks_1.json
@@ -1,0 +1,42 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#httpsHealthCheck", 
+        "description": "", 
+        "timeoutSec": 5, 
+        "checkIntervalSec": 10, 
+        "port": 443, 
+        "healthyThreshold": 2, 
+        "host": "", 
+        "requestPath": "/", 
+        "unhealthyThreshold": 3, 
+        "creationTimestamp": "2019-03-13T23:57:20.595-07:00", 
+        "id": "1274526500684842431", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks/newhealthcheck", 
+        "name": "newhealthcheck"
+      }
+    ], 
+    "kind": "compute#httpsHealthCheckList", 
+    "id": "projects/cloud-custodian/global/httpsHealthChecks", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "698", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 07:37:55 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 07:37:55 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/httpsHealthChecks?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"QbldhMMo_fTxJaG8W-5Z64RsGDo=/2ER5cKJYjunZPElIaM5b0MiM6ug=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-get/get-compute-v1-projects-cloud-custodian-global-sslCertificates-testcert_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-get/get-compute-v1-projects-cloud-custodian-global-sslCertificates-testcert_1.json
@@ -1,0 +1,28 @@
+{
+  "body": {
+    "kind": "compute#sslCertificate", 
+    "name": "testcert", 
+    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDAjCCAeqgAwIBAgIJAPUXF8V4YbOEMA0GCSqGSIb3DQEBCwUAMBYxFDASBgNV\nBAMMC2V4YW1wbGUuY29tMB4XDTE5MDMwNjE0MjE1NFoXDTIwMDMwNTE0MjE1NFow\nFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQDRrclYoZV7DoERFHJKRIK8wPUr4VVj4dsJn+SsMb96J5EsVNMd0QFp\nDsvn6E7Dg/Ujn1HohEUg+EsqFmDJSMcZO9nJxpTLGNP2GTgs3T5Z6ddouhBqXovG\ncY5c7t5TzRfZBbZPbhZu4nd6sJFbVIE90dRiqszPKuwHYBW5cV4n2zhMwx4BpgHT\nFGBqzIUaQhOWhV+STqlsKzWW6UpZrX4552pycJKIIHPEfU50dEnnr/z9laf3zf2i\nX+yBwGB2uJKix9rN5zfXOXC2JwYZ+8UE1kJ2b8RV93Qvnuc7htbUCCvZWqhOuPzB\nDQisYkL1XQv+LzQzWYj0ulC/AMd4ChU5AgMBAAGjUzBRMB0GA1UdDgQWBBTWGDWJ\n0cu9uR5LMdPc3pRhHw7ARzAfBgNVHSMEGDAWgBTWGDWJ0cu9uR5LMdPc3pRhHw7A\nRzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAmNR9sCJbIvSy8\nV8+CdFCZH+utP3sAtK4WY15lOlgBgfgGuXK9snfWU3B6SOFKttX0vsbQTzONShEX\nc9NDE+mbtlfYhiaAlUKUyV+w0N9xoenS1jIhrz0KByaKklAfPSJdSBwtzRZ9psIr\ncSueI2K1KTj4dxyYj4M78j/Z7LXgOVwBlInlTKGcSJd+qDRM0lSiZLQKt09qZFg8\nf6D8otR/o4LlauQONPAB91Vm/fJRVdiM5KD3aBK5jy0LMRA3iCVpItQf8gRH4ItO\n77+fpa0SHU58Gf+fDgyDCcXn77M0Ht5sBvuS5PB9BJHzc3VEWZeQXANXdM9e+zJj\nlpvn3RPW\n-----END CERTIFICATE-----\n\n", 
+    "creationTimestamp": "2019-03-06T07:33:58.591-08:00", 
+    "id": "733338214555866761", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "1402", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 08:57:07 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 08:57:07 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"ROdJYUw3NredrVJUI61-Wzgttbw=/a4I_lxU9_0Ym7B4yAuAIu9Avgwg=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-query/get-compute-v1-projects-cloud-custodian-global-sslCertificates_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-certificates-query/get-compute-v1-projects-cloud-custodian-global-sslCertificates_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#sslCertificate", 
+        "name": "testcert", 
+        "certificate": "-----BEGIN CERTIFICATE-----\nMIIDAjCCAeqgAwIBAgIJAPUXF8V4YbOEMA0GCSqGSIb3DQEBCwUAMBYxFDASBgNV\nBAMMC2V4YW1wbGUuY29tMB4XDTE5MDMwNjE0MjE1NFoXDTIwMDMwNTE0MjE1NFow\nFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAw\nggEKAoIBAQDRrclYoZV7DoERFHJKRIK8wPUr4VVj4dsJn+SsMb96J5EsVNMd0QFp\nDsvn6E7Dg/Ujn1HohEUg+EsqFmDJSMcZO9nJxpTLGNP2GTgs3T5Z6ddouhBqXovG\ncY5c7t5TzRfZBbZPbhZu4nd6sJFbVIE90dRiqszPKuwHYBW5cV4n2zhMwx4BpgHT\nFGBqzIUaQhOWhV+STqlsKzWW6UpZrX4552pycJKIIHPEfU50dEnnr/z9laf3zf2i\nX+yBwGB2uJKix9rN5zfXOXC2JwYZ+8UE1kJ2b8RV93Qvnuc7htbUCCvZWqhOuPzB\nDQisYkL1XQv+LzQzWYj0ulC/AMd4ChU5AgMBAAGjUzBRMB0GA1UdDgQWBBTWGDWJ\n0cu9uR5LMdPc3pRhHw7ARzAfBgNVHSMEGDAWgBTWGDWJ0cu9uR5LMdPc3pRhHw7A\nRzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQAmNR9sCJbIvSy8\nV8+CdFCZH+utP3sAtK4WY15lOlgBgfgGuXK9snfWU3B6SOFKttX0vsbQTzONShEX\nc9NDE+mbtlfYhiaAlUKUyV+w0N9xoenS1jIhrz0KByaKklAfPSJdSBwtzRZ9psIr\ncSueI2K1KTj4dxyYj4M78j/Z7LXgOVwBlInlTKGcSJd+qDRM0lSiZLQKt09qZFg8\nf6D8otR/o4LlauQONPAB91Vm/fJRVdiM5KD3aBK5jy0LMRA3iCVpItQf8gRH4ItO\n77+fpa0SHU58Gf+fDgyDCcXn77M0Ht5sBvuS5PB9BJHzc3VEWZeQXANXdM9e+zJj\nlpvn3RPW\n-----END CERTIFICATE-----\n\n", 
+        "creationTimestamp": "2019-03-06T07:33:58.591-08:00", 
+        "id": "733338214555866761", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+      }
+    ], 
+    "kind": "compute#sslCertificateList", 
+    "id": "projects/cloud-custodian/global/sslCertificates", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "1644", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 08:46:39 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 08:46:39 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"RqU1K4OGAIAU7BH9JXDsX6WnOJg=/q00WLCXHZi0U13t-w9EfyTkVKr0=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-get/get-compute-v1-projects-cloud-custodian-global-sslPolicies-newpolicy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-get/get-compute-v1-projects-cloud-custodian-global-sslPolicies-newpolicy_1.json
@@ -1,0 +1,47 @@
+{
+  "body": {
+    "profile": "COMPATIBLE", 
+    "kind": "compute#sslPolicy", 
+    "name": "newpolicy", 
+    "minTlsVersion": "TLS_1_0", 
+    "fingerprint": "BoVS1G-KySQ=", 
+    "creationTimestamp": "2019-03-11T05:40:52.917-07:00", 
+    "id": "4540081266450229691", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies/newpolicy", 
+    "enabledFeatures": [
+      "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA", 
+      "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", 
+      "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA", 
+      "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", 
+      "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256", 
+      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA", 
+      "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 
+      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA", 
+      "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 
+      "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256", 
+      "TLS_RSA_WITH_3DES_EDE_CBC_SHA", 
+      "TLS_RSA_WITH_AES_128_CBC_SHA", 
+      "TLS_RSA_WITH_AES_128_GCM_SHA256", 
+      "TLS_RSA_WITH_AES_256_CBC_SHA", 
+      "TLS_RSA_WITH_AES_256_GCM_SHA384"
+    ]
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "981", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 07:31:09 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 07:31:09 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies/newpolicy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"5YamndKM9WW73PHdKEZ714lkJMo=/QugbCU9qv-6vpC-rSZa1UXwUmlA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-query/get-compute-v1-projects-cloud-custodian-global-sslPolicies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-ssl-policies-query/get-compute-v1-projects-cloud-custodian-global-sslPolicies_1.json
@@ -1,0 +1,37 @@
+{
+  "body": {
+    "items": [
+      {
+        "profile": "COMPATIBLE", 
+        "kind": "compute#sslPolicy", 
+        "name": "newpolicy", 
+        "minTlsVersion": "TLS_1_0", 
+        "fingerprint": "BoVS1G-KySQ=", 
+        "creationTimestamp": "2019-03-11T05:40:52.917-07:00", 
+        "id": "4540081266450229691", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies/newpolicy"
+      }
+    ], 
+    "kind": "compute#sslPoliciesList", 
+    "id": "projects/cloud-custodian/global/sslPolicies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "574", 
+    "transfer-encoding": "chunked", 
+    "expires": "Mon, 11 Mar 2019 13:47:58 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Mon, 11 Mar 2019 13:47:58 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslPolicies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"BO6OAgfn40fb55us8CD5L5r-epc=/mL-qYVUneYpP6_H1kvEFR7Vp5LY=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-http-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetHttpProxies-new-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-http-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetHttpProxies-new-proxy_1.json
@@ -1,0 +1,28 @@
+{
+  "body": {
+    "kind": "compute#targetHttpProxy", 
+    "name": "new-proxy", 
+    "urlMap": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/new-url-map", 
+    "creationTimestamp": "2019-03-14T03:31:10.263-07:00", 
+    "id": "7476794674400170881", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "372", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 12:00:14 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 12:00:14 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-proxy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"CMV7mgal23anb8a58xTZWo9ecH8=/e3C5S-Oq9mz7KT-t8i7IEmo4MjA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-http-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetHttpProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-http-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetHttpProxies_1.json
@@ -1,0 +1,35 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetHttpProxy", 
+        "name": "new-proxy", 
+        "urlMap": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/new-url-map", 
+        "creationTimestamp": "2019-03-14T03:31:10.263-07:00", 
+        "id": "7476794674400170881", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies/new-proxy"
+      }
+    ], 
+    "kind": "compute#targetHttpProxyList", 
+    "id": "projects/cloud-custodian/global/targetHttpProxies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "619", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 11:57:28 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 11:57:28 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpProxies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"ZTdHnbY4A38t6fAHjJVuwe_zf-g=/8Ri2iF0VP59vwo_sgOMgucArodc=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies-newhttpslb-target-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies-newhttpslb-target-proxy_1.json
@@ -1,0 +1,32 @@
+{
+  "body": {
+    "kind": "compute#targetHttpsProxy", 
+    "name": "newhttpslb-target-proxy", 
+    "sslCertificates": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+    ], 
+    "quicOverride": "NONE", 
+    "urlMap": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/newhttpslb", 
+    "creationTimestamp": "2019-03-12T02:55:59.482-07:00", 
+    "id": "4375728720756489408", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies/newhttpslb-target-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "555", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 10:11:46 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 10:11:46 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies/newhttpslb-target-proxy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"NMHHfBnpRQTEvpTAtMvq4U-PaFo=/5qUEP7dlMP_W0xECWdgpcDba_gw=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-https-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetHttpsProxies_1.json
@@ -1,0 +1,39 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetHttpsProxy", 
+        "name": "newhttpslb-target-proxy", 
+        "sslCertificates": [
+          "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+        ], 
+        "quicOverride": "NONE", 
+        "urlMap": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/newhttpslb", 
+        "creationTimestamp": "2019-03-12T02:55:59.482-07:00", 
+        "id": "4375728720756489408", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies/newhttpslb-target-proxy"
+      }
+    ], 
+    "kind": "compute#targetHttpsProxyList", 
+    "id": "projects/cloud-custodian/global/targetHttpsProxies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "813", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 12 Mar 2019 10:05:06 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 12 Mar 2019 10:05:06 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetHttpsProxies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"K0ucKTIWbwDgbFV42ExeJSVnNt8=/2PmAVLbG_MKMajWkizyohnfhiIQ=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-instances-get/get-compute-v1-projects-cloud-custodian-zones-us-central1-a-targetInstances-new-target-instance_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-instances-get/get-compute-v1-projects-cloud-custodian-zones-us-central1-a-targetInstances-new-target-instance_1.json
@@ -1,0 +1,31 @@
+{
+  "body": {
+    "kind": "compute#targetInstance", 
+    "description": "", 
+    "zone": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a", 
+    "natPolicy": "NO_NAT", 
+    "instance": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/instances/new-instance", 
+    "creationTimestamp": "2019-03-14T06:41:40.217-07:00", 
+    "id": "4635391555730400507", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/targetInstances/new-target-instance", 
+    "name": "new-target-instance"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "563", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 14:08:19 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 14:08:19 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/targetInstances/new-target-instance?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"oDL9uE4Co2B-aq8Va3rB9--2ess=/6qn97v4HDgVxqB4uKO4paBkTMZI=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-instances-query/get-compute-v1-projects-cloud-custodian-aggregated-targetInstances_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-instances-query/get-compute-v1-projects-cloud-custodian-aggregated-targetInstances_1.json
@@ -1,0 +1,726 @@
+{
+  "body": {
+    "items": {
+      "zones/europe-west3-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west3-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west3-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west3-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west3-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west3-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-east2-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-east2-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-east2-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west3-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west3-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west3-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west2-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west2-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west2-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west2-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west2-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west2-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-central1-f": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-central1-f' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-central1-f", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-west2-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-west2-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-west2-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west1-d": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west1-d' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west1-d", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-east1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-east1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-east1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-east1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-east1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-east1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-east1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-east1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-east1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-west1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-west1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-west1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-west1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-west1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-west1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-west2-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-west2-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-west2-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/southamerica-east1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/southamerica-east1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/southamerica-east1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/southamerica-east1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/southamerica-east1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/southamerica-east1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/southamerica-east1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/southamerica-east1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/southamerica-east1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west2-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west2-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west2-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-east2-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-east2-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-east2-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-north1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-north1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-north1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-east1-d": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-east1-d' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-east1-d", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-north1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-north1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-north1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west6-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west6-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west6-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-east1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-east1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-east1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/australia-southeast1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/australia-southeast1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/australia-southeast1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-east1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-east1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-east1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west6-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west6-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west6-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-southeast1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-southeast1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-southeast1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-southeast1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-southeast1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-southeast1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-north1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-north1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-north1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-southeast1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-southeast1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-southeast1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-east2-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-east2-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-east2-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/australia-southeast1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/australia-southeast1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/australia-southeast1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-central1-a": {
+        "targetInstances": [
+          {
+            "kind": "compute#targetInstance", 
+            "description": "", 
+            "zone": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a", 
+            "natPolicy": "NO_NAT", 
+            "instance": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/instances/new-instance", 
+            "creationTimestamp": "2019-03-14T06:41:40.217-07:00", 
+            "id": "4635391555730400507", 
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/zones/us-central1-a/targetInstances/new-target-instance", 
+            "name": "new-target-instance"
+          }
+        ]
+      }, 
+      "zones/asia-south1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-south1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-south1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-central1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-central1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-central1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-central1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-central1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-central1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west6-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west6-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west6-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-northeast1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-northeast1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-northeast1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-northeast1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-northeast1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-northeast1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-northeast1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-northeast1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-northeast1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-west1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-west1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-west1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-east4-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-east4-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-east4-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-south1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-south1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-south1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-east4-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-east4-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-east4-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-east4-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-east4-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-east4-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west4-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west4-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west4-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west4-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west4-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west4-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/europe-west4-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/europe-west4-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/europe-west4-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/us-west2-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/us-west2-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/us-west2-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/northamerica-northeast1-c": {
+        "warning": {
+          "message": "There are no results for scope 'zones/northamerica-northeast1-c' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/northamerica-northeast1-c", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/asia-south1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/asia-south1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/asia-south1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/northamerica-northeast1-a": {
+        "warning": {
+          "message": "There are no results for scope 'zones/northamerica-northeast1-a' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/northamerica-northeast1-a", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/australia-southeast1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/australia-southeast1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/australia-southeast1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "zones/northamerica-northeast1-b": {
+        "warning": {
+          "message": "There are no results for scope 'zones/northamerica-northeast1-b' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "zones/northamerica-northeast1-b", 
+              "key": "scope"
+            }
+          ]
+        }
+      }
+    }, 
+    "kind": "compute#targetInstanceAggregatedList", 
+    "id": "projects/cloud-custodian/aggregated/targetInstances", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/targetInstances"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "16277", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 14:01:42 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 14:01:42 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/targetInstances?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"xtGj8zdkzQ6EFqxCJmgKW7kEFzc=/Bt46VEGXgcqqpHb9uOOk5xwfgq4=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-pools-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-targetPools-new-target-pool_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-pools-get/get-compute-v1-projects-cloud-custodian-regions-us-central1-targetPools-new-target-pool_1.json
@@ -1,0 +1,30 @@
+{
+  "body": {
+    "kind": "compute#targetPool", 
+    "description": "", 
+    "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1", 
+    "sessionAffinity": "NONE", 
+    "creationTimestamp": "2019-03-14T07:13:42.486-07:00", 
+    "id": "3014923708032081785", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/new-target-pool", 
+    "name": "new-target-pool"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "427", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 14:29:00 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 14:29:00 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/new-target-pool?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"FKgfGqjn7Q_We4aoMTmvnzzcJJ0=/8582l1Z9pmpJI4Hu72r4LZXGj58=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-pools-query/get-compute-v1-projects-cloud-custodian-aggregated-targetPools_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-pools-query/get-compute-v1-projects-cloud-custodian-aggregated-targetPools_1.json
@@ -1,0 +1,257 @@
+{
+  "body": {
+    "items": {
+      "regions/us-west2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-west2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-west2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-northeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-northeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-northeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-west1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-west1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-west1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/southamerica-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/southamerica-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/southamerica-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west6": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west6' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west6", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west4": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west4' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west4", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-north1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-north1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-north1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-southeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-southeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-southeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-east4": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-east4' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-east4", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/europe-west3": {
+        "warning": {
+          "message": "There are no results for scope 'regions/europe-west3' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/europe-west3", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/australia-southeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/australia-southeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/australia-southeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/asia-south1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-south1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-south1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-east1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/us-east1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/us-east1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/us-central1": {
+        "targetPools": [
+          {
+            "kind": "compute#targetPool", 
+            "description": "", 
+            "region": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1", 
+            "sessionAffinity": "NONE", 
+            "creationTimestamp": "2019-03-14T07:13:42.486-07:00", 
+            "id": "3014923708032081785", 
+            "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/regions/us-central1/targetPools/new-target-pool", 
+            "name": "new-target-pool"
+          }
+        ]
+      }, 
+      "regions/asia-east2": {
+        "warning": {
+          "message": "There are no results for scope 'regions/asia-east2' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/asia-east2", 
+              "key": "scope"
+            }
+          ]
+        }
+      }, 
+      "regions/northamerica-northeast1": {
+        "warning": {
+          "message": "There are no results for scope 'regions/northamerica-northeast1' on this page.", 
+          "code": "NO_RESULTS_ON_PAGE", 
+          "data": [
+            {
+              "value": "regions/northamerica-northeast1", 
+              "key": "scope"
+            }
+          ]
+        }
+      }
+    }, 
+    "kind": "compute#targetPoolAggregatedList", 
+    "id": "projects/cloud-custodian/aggregated/targetPools", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/targetPools"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "5612", 
+    "transfer-encoding": "chunked", 
+    "expires": "Thu, 14 Mar 2019 14:26:43 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Thu, 14 Mar 2019 14:26:43 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/aggregated/targetPools?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"Bdbc5AKgxPYLZEkaXaCtSF3wSr8=/xyq_HcHunwL8LU1qAZcthi3Uiz8=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetSslProxies-lb2-target-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetSslProxies-lb2-target-proxy_1.json
@@ -1,0 +1,32 @@
+{
+  "body": {
+    "kind": "compute#targetSslProxy", 
+    "name": "lb2-target-proxy", 
+    "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/lb2", 
+    "proxyHeader": "NONE", 
+    "sslCertificates": [
+      "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+    ], 
+    "creationTimestamp": "2019-03-06T07:34:34.302-08:00", 
+    "id": "1917928467246241381", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies/lb2-target-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "538", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 06 Mar 2019 15:52:27 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 06 Mar 2019 15:52:27 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies/lb2-target-proxy?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"0GDkhZBjF4Vl_NZyDhDapyfB20Y=/fqK7bOxgEqUDindToHnwaiDdIUo=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetSslProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-ssl-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetSslProxies_1.json
@@ -1,0 +1,39 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetSslProxy", 
+        "name": "lb2-target-proxy", 
+        "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/lb2", 
+        "proxyHeader": "NONE", 
+        "sslCertificates": [
+          "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/sslCertificates/testcert"
+        ], 
+        "creationTimestamp": "2019-03-06T07:34:34.302-08:00", 
+        "id": "1917928467246241381", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies/lb2-target-proxy"
+      }
+    ], 
+    "kind": "compute#targetSslProxyList", 
+    "id": "projects/cloud-custodian/global/targetSslProxies", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "790", 
+    "transfer-encoding": "chunked", 
+    "expires": "Wed, 06 Mar 2019 15:43:36 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Wed, 06 Mar 2019 15:43:36 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetSslProxies?alt=json", 
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"jX1ObjVrPdjOKpn9s7Q9IbijGiE=/9mMCTQywZIr1ASzGq-GHI3Ah8Lg=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies-newlb1-target-proxy_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-get/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies-newlb1-target-proxy_1.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "kind": "compute#targetTcpProxy", 
+    "name": "newlb1-target-proxy", 
+    "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/newlb1",
+    "proxyHeader": "NONE", 
+    "creationTimestamp": "2019-03-05T05:49:38.606-08:00", 
+    "id": "3552848673737261213", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies/newlb1-target-proxy"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "418", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 14:12:17 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 14:12:17 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies/newlb1-target-proxy?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"gYA0b9KQ4ktU6RX4y1bWgvSsav8=/klbwc7Cui-xUB-l_RDnJK9dGtQs=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-target-tcp-proxies-query/get-compute-v1-projects-cloud-custodian-global-targetTcpProxies_1.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#targetTcpProxy", 
+        "name": "newlb1-target-proxy", 
+        "service": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendServices/newlb1",
+        "proxyHeader": "NONE", 
+        "creationTimestamp": "2019-03-05T05:49:38.606-08:00", 
+        "id": "3552848673737261213", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies/newlb1-target-proxy"
+      }
+    ], 
+    "kind": "compute#targetTcpProxyList", 
+    "id": "projects/cloud-custodian/global/targetTcpProxies",
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "664", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 14:03:40 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 14:03:40 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/targetTcpProxies?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"BoLeW5srDJVlcBxw0SzFLfo-ad0=/0obzakJ-_dWI3wmY1iTLBu43BDo=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-url-maps-get/get-compute-v1-projects-cloud-custodian-global-urlMaps-lb_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-url-maps-get/get-compute-v1-projects-cloud-custodian-global-urlMaps-lb_1.json
@@ -1,0 +1,29 @@
+{
+  "body": {
+    "kind": "compute#urlMap", 
+    "name": "lb", 
+    "defaultService": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket",
+    "fingerprint": "GMqHBoGzLDY=", 
+    "creationTimestamp": "2019-03-05T04:30:37.636-08:00", 
+    "id": "1361403814964614402", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/lb"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "384", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 12:57:18 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 12:57:18 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/lb?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"BX6bAoC-XMD-cmKexD3O7zolrRU=/DJhFiC07cecs8EJmUCxjab7iQKA=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/data/flights/lb-url-maps-query/get-compute-v1-projects-cloud-custodian-global-urlMaps_1.json
+++ b/tools/c7n_gcp/tests/data/flights/lb-url-maps-query/get-compute-v1-projects-cloud-custodian-global-urlMaps_1.json
@@ -1,0 +1,36 @@
+{
+  "body": {
+    "items": [
+      {
+        "kind": "compute#urlMap", 
+        "name": "lb", 
+        "defaultService": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/backendBuckets/newbucket",
+        "fingerprint": "GMqHBoGzLDY=", 
+        "creationTimestamp": "2019-03-05T04:30:37.636-08:00", 
+        "id": "1361403814964614402", 
+        "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps/lb"
+      }
+    ], 
+    "kind": "compute#urlMapList", 
+    "id": "projects/decoded-pier-228312/global/urlMaps", 
+    "selfLink": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps"
+  }, 
+  "headers": {
+    "status": "200", 
+    "content-length": "604", 
+    "transfer-encoding": "chunked", 
+    "expires": "Tue, 05 Mar 2019 12:40:15 GMT", 
+    "vary": "Origin, X-Origin", 
+    "-content-encoding": "gzip", 
+    "date": "Tue, 05 Mar 2019 12:40:15 GMT", 
+    "x-xss-protection": "1; mode=block", 
+    "content-location": "https://www.googleapis.com/compute/v1/projects/cloud-custodian/global/urlMaps?alt=json",
+    "x-content-type-options": "nosniff", 
+    "server": "GSE", 
+    "etag": "\"YImFd31hoU8xJL-6lFwB5eFe_e8=/ERkA9A1vX3FdxQwbWfgCfVbjsDw=\"", 
+    "cache-control": "private, max-age=0, must-revalidate, no-transform", 
+    "x-frame-options": "SAMEORIGIN", 
+    "alt-svc": "quic=\":443\"; ma=2592000; v=\"46,44,43,39\"", 
+    "content-type": "application/json; charset=UTF-8"
+  }
+}

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -378,3 +378,33 @@ class LoadBalancingBackendServiceTest(BaseTest):
              'name': 'new-backend-service'})
         self.assertEqual(instance['kind'], 'compute#backendService')
         self.assertEqual(instance['name'], 'new-backend-service')
+
+
+class LoadBalancingTargetInstanceTest(BaseTest):
+
+    def test_loadbalancing_target_instance_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-instances-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-instances',
+             'resource': 'gcp.loadbalancing-target-instance'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetInstance')
+        self.assertEqual(resources[0]['name'], 'new-target-instance')
+
+    def test_loadbalancing_target_instance_get(self):
+        zone = '/compute/v1/projects/cloud-custodian/zones/us-central1-a'
+        factory = self.replay_flight_data('lb-target-instances-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-instances',
+             'resource': 'gcp.loadbalancing-target-instance'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'zone': zone,
+             'name': 'new-target-instance'})
+        self.assertEqual(instance['kind'], 'compute#targetInstance')
+        self.assertEqual(instance['name'], 'new-target-instance')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -498,3 +498,33 @@ class LoadBalancingGlobalForwardingRuleTest(BaseTest):
              'name': 'new-global-frontend'})
         self.assertEqual(instance['kind'], 'compute#forwardingRule')
         self.assertEqual(instance['name'], 'new-global-frontend')
+
+
+class LoadBalancingGlobalAddressTest(BaseTest):
+
+    def test_loadbalancing_global_address_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-global-addresses-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-global-addresses',
+             'resource': 'gcp.loadbalancing-global-address'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#address')
+        self.assertEqual(resources[0]['name'], 'new-global-address')
+
+    def test_loadbalancing_global_address_get(self):
+        region = '/compute/v1/projects/cloud-custodian/zones/us-central1'
+        factory = self.replay_flight_data('lb-global-addresses-get')
+        p = self.load_policy(
+            {'name': 'one-lb-global-addresses',
+             'resource': 'gcp.loadbalancing-global-address'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'region': region,
+             'name': 'new-global-address'})
+        self.assertEqual(instance['kind'], 'compute#address')
+        self.assertEqual(instance['name'], 'new-global-address')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -408,3 +408,33 @@ class LoadBalancingTargetInstanceTest(BaseTest):
              'name': 'new-target-instance'})
         self.assertEqual(instance['kind'], 'compute#targetInstance')
         self.assertEqual(instance['name'], 'new-target-instance')
+
+
+class LoadBalancingTargetPoolTest(BaseTest):
+
+    def test_loadbalancing_target_pool_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-pools-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-pools',
+             'resource': 'gcp.loadbalancing-target-pool'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetPool')
+        self.assertEqual(resources[0]['name'], 'new-target-pool')
+
+    def test_loadbalancing_target_pool_get(self):
+        region = '/compute/v1/projects/cloud-custodian/zones/us-central1'
+        factory = self.replay_flight_data('lb-target-pools-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-pools',
+             'resource': 'gcp.loadbalancing-target-pool'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'region': region,
+             'name': 'new-target-pool'})
+        self.assertEqual(instance['kind'], 'compute#targetPool')
+        self.assertEqual(instance['name'], 'new-target-pool')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -294,3 +294,31 @@ class LoadBalancingHttpHealthCheckTest(BaseTest):
              'name': 'newhttphealthcheck'})
         self.assertEqual(instance['kind'], 'compute#httpHealthCheck')
         self.assertEqual(instance['name'], 'newhttphealthcheck')
+
+
+class LoadBalancingHealthCheckTest(BaseTest):
+
+    def test_loadbalancing_health_check_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-health-checks-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-health-checks',
+             'resource': 'gcp.loadbalancing-health-check'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#healthCheck')
+        self.assertEqual(resources[0]['name'], 'new-tcp-health-check')
+
+    def test_loadbalancing_health_check_get(self):
+        factory = self.replay_flight_data('lb-health-checks-get')
+        p = self.load_policy(
+            {'name': 'one-lb-health-checks',
+             'resource': 'gcp.loadbalancing-health-check'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'new-tcp-health-check'})
+        self.assertEqual(instance['kind'], 'compute#healthCheck')
+        self.assertEqual(instance['name'], 'new-tcp-health-check')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -42,3 +42,31 @@ class LoadBalancingAddressTest(BaseTest):
              'region': 'us-central1'})
         self.assertEqual(instance['kind'], 'compute#address')
         self.assertEqual(instance['address'], '35.193.10.19')
+
+
+class LoadBalancingUrlMapTest(BaseTest):
+
+    def test_loadbalancing_url_map_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-url-maps-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-url-maps',
+             'resource': 'gcp.loadbalancing-url-map'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#urlMap')
+        self.assertEqual(resources[0]['fingerprint'], 'GMqHBoGzLDY=')
+
+    def test_loadbalancing_url_map_get(self):
+        factory = self.replay_flight_data('lb-url-maps-get')
+        p = self.load_policy(
+            {'name': 'one-lb-url-map',
+             'resource': 'gcp.loadbalancing-url-map'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'urlMap': 'lb'})
+        self.assertEqual(instance['kind'], 'compute#urlMap')
+        self.assertEqual(instance['fingerprint'], 'GMqHBoGzLDY=')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -322,3 +322,31 @@ class LoadBalancingHealthCheckTest(BaseTest):
              'name': 'new-tcp-health-check'})
         self.assertEqual(instance['kind'], 'compute#healthCheck')
         self.assertEqual(instance['name'], 'new-tcp-health-check')
+
+
+class LoadBalancingTargetHttpProxyTest(BaseTest):
+
+    def test_loadbalancing_target_http_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-http-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-http-proxies',
+             'resource': 'gcp.loadbalancing-target-http-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetHttpProxy')
+        self.assertEqual(resources[0]['name'], 'new-proxy')
+
+    def test_loadbalancing_target_http_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-http-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-http-proxies',
+             'resource': 'gcp.loadbalancing-target-http-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'new-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetHttpProxy')
+        self.assertEqual(instance['name'], 'new-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -37,8 +37,8 @@ class LoadBalancingAddressTest(BaseTest):
              'resource': 'gcp.loadbalancing-address'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'address': 'new1',
+            {'project_id': 'cloud-custodian',
+             'name': 'new1',
              'region': 'us-central1'})
         self.assertEqual(instance['kind'], 'compute#address')
         self.assertEqual(instance['address'], '35.193.10.19')
@@ -66,8 +66,8 @@ class LoadBalancingUrlMapTest(BaseTest):
              'resource': 'gcp.loadbalancing-url-map'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'urlMap': 'lb'})
+            {'project_id': 'cloud-custodian',
+             'name': 'lb'})
         self.assertEqual(instance['kind'], 'compute#urlMap')
         self.assertEqual(instance['fingerprint'], 'GMqHBoGzLDY=')
 
@@ -94,8 +94,8 @@ class LoadBalancingTargetTcpProxyTest(BaseTest):
              'resource': 'gcp.loadbalancing-target-tcp-proxy'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'targetTcpProxy': 'newlb1-target-proxy'})
+            {'project_id': 'cloud-custodian',
+             'name': 'newlb1-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetTcpProxy')
         self.assertEqual(instance['name'], 'newlb1-target-proxy')
 
@@ -122,7 +122,7 @@ class LoadBalancingTargetSslProxyTest(BaseTest):
              'resource': 'gcp.loadbalancing-target-ssl-proxy'},
             session_factory=factory)
         instance = p.resource_manager.get_resource(
-            {'project': 'cloud-custodian',
-             'targetSslProxy': 'lb2-target-proxy'})
+            {'project_id': 'cloud-custodian',
+             'name': 'lb2-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetSslProxy')
         self.assertEqual(instance['name'], 'lb2-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -98,3 +98,31 @@ class LoadBalancingTargetTcpProxyTest(BaseTest):
              'targetTcpProxy': 'newlb1-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetTcpProxy')
         self.assertEqual(instance['name'], 'newlb1-target-proxy')
+
+
+class LoadBalancingTargetSslProxyTest(BaseTest):
+
+    def test_loadbalancing_target_ssl_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-ssl-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-ssl-proxies',
+             'resource': 'gcp.loadbalancing-target-ssl-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetSslProxy')
+        self.assertEqual(resources[0]['name'], 'lb2-target-proxy')
+
+    def test_loadbalancing_target_ssl_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-ssl-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-ssl-proxy',
+             'resource': 'gcp.loadbalancing-target-ssl-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'targetSslProxy': 'lb2-target-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetSslProxy')
+        self.assertEqual(instance['name'], 'lb2-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -266,3 +266,31 @@ class LoadBalancingHttpsHealthCheckTest(BaseTest):
              'name': 'newhealthcheck'})
         self.assertEqual(instance['kind'], 'compute#httpsHealthCheck')
         self.assertEqual(instance['name'], 'newhealthcheck')
+
+
+class LoadBalancingHttpHealthCheckTest(BaseTest):
+
+    def test_loadbalancing_http_health_check_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-http-health-checks-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-http-health-checks',
+             'resource': 'gcp.loadbalancing-http-health-check'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#httpHealthCheck')
+        self.assertEqual(resources[0]['name'], 'newhttphealthcheck')
+
+    def test_loadbalancing_http_health_check_get(self):
+        factory = self.replay_flight_data('lb-http-health-checks-get')
+        p = self.load_policy(
+            {'name': 'one-lb-http-health-checks',
+             'resource': 'gcp.loadbalancing-http-health-check'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newhttphealthcheck'})
+        self.assertEqual(instance['kind'], 'compute#httpHealthCheck')
+        self.assertEqual(instance['name'], 'newhttphealthcheck')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -126,3 +126,31 @@ class LoadBalancingTargetSslProxyTest(BaseTest):
              'name': 'lb2-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetSslProxy')
         self.assertEqual(instance['name'], 'lb2-target-proxy')
+
+
+class LoadBalancingSslPolicyTest(BaseTest):
+
+    def test_loadbalancing_ssl_policy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-ssl-policies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-ssl-policies',
+             'resource': 'gcp.loadbalancing-ssl-policy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#sslPolicy')
+        self.assertEqual(resources[0]['name'], 'newpolicy')
+
+    def test_loadbalancing_ssl_policy_get(self):
+        factory = self.replay_flight_data('lb-ssl-policies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-ssl-policies',
+             'resource': 'gcp.loadbalancing-ssl-policy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newpolicy'})
+        self.assertEqual(instance['kind'], 'compute#sslPolicy')
+        self.assertEqual(instance['name'], 'newpolicy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -210,3 +210,31 @@ class LoadBalancingTargetHttpsProxyTest(BaseTest):
              'name': 'newhttpslb-target-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetHttpsProxy')
         self.assertEqual(instance['name'], 'newhttpslb-target-proxy')
+
+
+class LoadBalancingBackendBucketTest(BaseTest):
+
+    def test_loadbalancing_backend_bucket_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-backend-buckets-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-backend-buckets',
+             'resource': 'gcp.loadbalancing-backend-bucket'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#backendBucket')
+        self.assertEqual(resources[0]['name'], 'newbucket')
+
+    def test_loadbalancing_backend_bucket_get(self):
+        factory = self.replay_flight_data('lb-backend-buckets-get')
+        p = self.load_policy(
+            {'name': 'one-lb-backend-buckets',
+             'resource': 'gcp.loadbalancing-backend-bucket'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newbucket'})
+        self.assertEqual(instance['kind'], 'compute#backendBucket')
+        self.assertEqual(instance['name'], 'newbucket')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -70,3 +70,31 @@ class LoadBalancingUrlMapTest(BaseTest):
              'urlMap': 'lb'})
         self.assertEqual(instance['kind'], 'compute#urlMap')
         self.assertEqual(instance['fingerprint'], 'GMqHBoGzLDY=')
+
+
+class LoadBalancingTargetTcpProxyTest(BaseTest):
+
+    def test_loadbalancing_target_tcp_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-tcp-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-tcp-proxies',
+             'resource': 'gcp.loadbalancing-target-tcp-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetTcpProxy')
+        self.assertEqual(resources[0]['name'], 'newlb1-target-proxy')
+
+    def test_loadbalancing_target_tcp_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-tcp-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-tcp-proxy',
+             'resource': 'gcp.loadbalancing-target-tcp-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'targetTcpProxy': 'newlb1-target-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetTcpProxy')
+        self.assertEqual(instance['name'], 'newlb1-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -238,3 +238,31 @@ class LoadBalancingBackendBucketTest(BaseTest):
              'name': 'newbucket'})
         self.assertEqual(instance['kind'], 'compute#backendBucket')
         self.assertEqual(instance['name'], 'newbucket')
+
+
+class LoadBalancingHttpsHealthCheckTest(BaseTest):
+
+    def test_loadbalancing_https_health_check_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-https-health-checks-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-https-health-checks',
+             'resource': 'gcp.loadbalancing-https-health-check'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#httpsHealthCheck')
+        self.assertEqual(resources[0]['name'], 'newhealthcheck')
+
+    def test_loadbalancing_https_health_check_get(self):
+        factory = self.replay_flight_data('lb-https-health-checks-get')
+        p = self.load_policy(
+            {'name': 'one-lb-https-health-checks',
+             'resource': 'gcp.loadbalancing-https-health-check'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newhealthcheck'})
+        self.assertEqual(instance['kind'], 'compute#httpsHealthCheck')
+        self.assertEqual(instance['name'], 'newhealthcheck')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -438,3 +438,33 @@ class LoadBalancingTargetPoolTest(BaseTest):
              'name': 'new-target-pool'})
         self.assertEqual(instance['kind'], 'compute#targetPool')
         self.assertEqual(instance['name'], 'new-target-pool')
+
+
+class LoadBalancingForwardingRuleTest(BaseTest):
+
+    def test_loadbalancing_forwarding_rule_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-forwarding-rules-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-forwarding-rules',
+             'resource': 'gcp.loadbalancing-forwarding-rule'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#forwardingRule')
+        self.assertEqual(resources[0]['name'], 'new-fe')
+
+    def test_loadbalancing_forwarding_rule_get(self):
+        region = '/compute/v1/projects/cloud-custodian/zones/us-central1'
+        factory = self.replay_flight_data('lb-forwarding-rules-get')
+        p = self.load_policy(
+            {'name': 'one-lb-forwarding-rules',
+             'resource': 'gcp.loadbalancing-forwarding-rule'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'region': region,
+             'name': 'new-fe'})
+        self.assertEqual(instance['kind'], 'compute#forwardingRule')
+        self.assertEqual(instance['name'], 'new-fe')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -1,0 +1,44 @@
+# Copyright 2019 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gcp_common import BaseTest
+
+
+class LoadBalancingAddressTest(BaseTest):
+
+    def test_loadbalancing_address_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-addresses-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-addresses',
+             'resource': 'gcp.loadbalancing-address'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#address')
+        self.assertEqual(resources[0]['address'], '35.193.10.19')
+
+    def test_loadbalancing_address_get(self):
+        factory = self.replay_flight_data('lb-addresses-get')
+        p = self.load_policy(
+            {'name': 'one-region-address',
+             'resource': 'gcp.loadbalancing-address'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project': 'cloud-custodian',
+             'address': 'new1',
+             'region': 'us-central1'})
+        self.assertEqual(instance['kind'], 'compute#address')
+        self.assertEqual(instance['address'], '35.193.10.19')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -154,3 +154,59 @@ class LoadBalancingSslPolicyTest(BaseTest):
              'name': 'newpolicy'})
         self.assertEqual(instance['kind'], 'compute#sslPolicy')
         self.assertEqual(instance['name'], 'newpolicy')
+
+
+class LoadBalancingSslCertificateTest(BaseTest):
+
+    def test_loadbalancing_ssl_certificate_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-ssl-certificates-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-ssl-certificates',
+             'resource': 'gcp.loadbalancing-ssl-certificate'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#sslCertificate')
+        self.assertEqual(resources[0]['name'], 'testcert')
+
+    def test_loadbalancing_ssl_certificate_get(self):
+        factory = self.replay_flight_data('lb-ssl-certificates-get')
+        p = self.load_policy(
+            {'name': 'one-lb-ssl-certificates',
+             'resource': 'gcp.loadbalancing-ssl-certificate'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'testcert'})
+        self.assertEqual(instance['kind'], 'compute#sslCertificate')
+        self.assertEqual(instance['name'], 'testcert')
+
+
+class LoadBalancingTargetHttpsProxyTest(BaseTest):
+
+    def test_loadbalancing_target_https_proxy_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-target-https-proxies-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-target-https-proxies',
+             'resource': 'gcp.loadbalancing-target-https-proxy'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#targetHttpsProxy')
+        self.assertEqual(resources[0]['name'], 'newhttpslb-target-proxy')
+
+    def test_loadbalancing_target_https_proxy_get(self):
+        factory = self.replay_flight_data('lb-target-https-proxies-get')
+        p = self.load_policy(
+            {'name': 'one-lb-target-https-proxies',
+             'resource': 'gcp.loadbalancing-target-https-proxy'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'newhttpslb-target-proxy'})
+        self.assertEqual(instance['kind'], 'compute#targetHttpsProxy')
+        self.assertEqual(instance['name'], 'newhttpslb-target-proxy')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -468,3 +468,33 @@ class LoadBalancingForwardingRuleTest(BaseTest):
              'name': 'new-fe'})
         self.assertEqual(instance['kind'], 'compute#forwardingRule')
         self.assertEqual(instance['name'], 'new-fe')
+
+
+class LoadBalancingGlobalForwardingRuleTest(BaseTest):
+
+    def test_loadbalancing_global_forwarding_rule_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-global-forwarding-rules-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-global-forwarding-rules',
+             'resource': 'gcp.loadbalancing-global-forwarding-rule'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#forwardingRule')
+        self.assertEqual(resources[0]['name'], 'new-global-frontend')
+
+    def test_loadbalancing_global_forwarding_rule_get(self):
+        region = '/compute/v1/projects/cloud-custodian/zones/us-central1'
+        factory = self.replay_flight_data('lb-global-forwarding-rules-get')
+        p = self.load_policy(
+            {'name': 'one-lb-global-forwarding-rules',
+             'resource': 'gcp.loadbalancing-global-forwarding-rule'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'region': region,
+             'name': 'new-global-frontend'})
+        self.assertEqual(instance['kind'], 'compute#forwardingRule')
+        self.assertEqual(instance['name'], 'new-global-frontend')

--- a/tools/c7n_gcp/tests/test_loadbalancing.py
+++ b/tools/c7n_gcp/tests/test_loadbalancing.py
@@ -350,3 +350,31 @@ class LoadBalancingTargetHttpProxyTest(BaseTest):
              'name': 'new-proxy'})
         self.assertEqual(instance['kind'], 'compute#targetHttpProxy')
         self.assertEqual(instance['name'], 'new-proxy')
+
+
+class LoadBalancingBackendServiceTest(BaseTest):
+
+    def test_loadbalancing_backend_service_query(self):
+        project_id = 'cloud-custodian'
+        factory = self.replay_flight_data('lb-backend-services-query',
+                                          project_id=project_id)
+        p = self.load_policy(
+            {'name': 'all-lb-backend-services',
+             'resource': 'gcp.loadbalancing-backend-service'},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['kind'], 'compute#backendService')
+        self.assertEqual(resources[0]['name'], 'new-backend-service')
+
+    def test_loadbalancing_backend_service_get(self):
+        factory = self.replay_flight_data('lb-backend-services-get')
+        p = self.load_policy(
+            {'name': 'one-lb-backend-services',
+             'resource': 'gcp.loadbalancing-backend-service'},
+            session_factory=factory)
+        instance = p.resource_manager.get_resource(
+            {'project_id': 'cloud-custodian',
+             'name': 'new-backend-service'})
+        self.assertEqual(instance['kind'], 'compute#backendService')
+        self.assertEqual(instance['name'], 'new-backend-service')


### PR DESCRIPTION
Added initial classes with `query` and `get` functionality for the following resources in `LoadBalancing` service

- Addresses
- Backend buckets
- Backend Sevices
- Forwarding Rules
- Global Addresses
- Global Forwarding Rules
- Health Checks
- HTTP Health Checks
- HTTPS Health Checks
- SSL Certificates
- SSL Policies
- Target HTTP Proxies
- Target HTTPS Proxies
- Target Instances
- Target Pools
- Target SSL Proxies
- Target TCP Proxies
- URL Maps