### PR TITLE
gcp - [PoC] add 'query' scope to unwrap filter values

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -41,7 +41,7 @@ class ResourceQuery(object):
             m.service, m.version, m.component)
 
         # depends on resource scope
-        if m.scope in ('project', 'zone'):
+        if m.scope in ('project', 'zone', 'query'):
             project = session.get_default_project()
             if m.scope_template:
                 project = m.scope_template.format(project)
@@ -53,6 +53,14 @@ class ResourceQuery(object):
         if m.scope == 'zone':
             if session.get_default_zone():
                 params['zone'] = session.get_default_zone()
+
+        # unwraps the filter values that were added
+        # to params in get_resource_query()
+        if m.scope == 'query' and 'filter' in params:
+            query_params = params['filter'][0]
+            del(params['filter'])
+            for key, value in query_params.items():
+                params[key] = value
 
         enum_op, path, extra_args = m.enum_spec
         if extra_args:


### PR DESCRIPTION
**Changes**

Fixes the behavior of get_resource_query() (QueryResourceManager in query.py) so that the parameters sent via query could be picked up by GCP client. On the one hand, the initial code is untouched to stay away from possible regressions. On the other hand, it allows the logic to be reused rather than overriding the base method in every required QueryResourceManager implementation. In addition, the scope has been added to the ones that need default project id in the parameters.

**Motivation**

Support list actions that require parameters other than project id by specifying them in query block in a policy.

**Example**

List [ResourceRecordSets](https://cloud.google.com/dns/docs/reference/v1beta2/resourceRecordSets/list):

_policy.yml_
```
policies:
    - name: my-first-policy
      query:
        - managedZone: custodian
      resource: gcp.dns-rrsets
```

_[dns.py](https://github.com/cloud-custodian/cloud-custodian/compare/master...mediapills:feature/dns)_
```
@resources.register('dns-rrsets')
class ResourceRecordSets(QueryResourceManager):

    class resource_type(TypeInfo):
        service = 'dns'
        version = 'v1beta2'
        component = 'resourceRecordSets'
        enum_spec = ('list', 'rrsets[]', None)
        scope = 'query'

        @staticmethod
        def get(client, resource_info):
            return client.execute_query(
                'get', {'project': resource_info['project_id'],
                        'managedZone': resource_info['name']})
```