### PR TITLE
gcp - [PoC] add support for more than one param in url (option 1)

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -38,6 +38,7 @@ from c7n.policy import execution
 from c7n.provider import clouds
 from c7n.resources import load_resources
 from c7n.filters import ValueFilter, EventFilter, AgeFilter
+from c7n_gcp.query import SCOPE_TYPE_CUSTOM_SCOPE
 
 
 def validate(data, schema=None):
@@ -355,6 +356,10 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None, d
 
     if type_name == 'ec2':
         resource_policy['allOf'][1]['properties']['query'] = {}
+
+    r_type = resource_type.resource_type
+    if getattr(r_type, 'scope', '') == SCOPE_TYPE_CUSTOM_SCOPE:
+        r_type.extended_policy(definitions)
 
     r['policy'] = resource_policy
     return {'$ref': '#/definitions/resources/%s/policy' % type_name}

--- a/policy.yml
+++ b/policy.yml
@@ -1,0 +1,6 @@
+policies:
+    - name: my-first-policy
+      description: |
+        Adds a tag to all virtual machines
+      resource: gcp.log-billing-account-exclusion
+      billing_account_id: -----------------

--- a/tools/c7n_gcp/c7n_gcp/resources/logging.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/logging.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from c7n_gcp.provider import resources
-from c7n_gcp.query import QueryResourceManager, TypeInfo
+from c7n_gcp.query import QueryResourceManager, TypeInfo, CustomScopeTypeInfo
+
 
 # TODO .. folder, billing account, org sink
 # how to map them given a project level root entity sans use of c7n-org
@@ -35,3 +36,16 @@ class LogSink(QueryResourceManager):
             return client.get('get', {
                 'sinkName': 'projects/{project_id}/sinks/{name}'.format(
                     **resource_info)})
+
+
+@resources.register('log-billing-account-exclusion')
+class LogBillingAccountExclusion(QueryResourceManager):
+
+    class resource_type(CustomScopeTypeInfo):
+        service = 'logging'
+        version = 'v2'
+        component = 'exclusions'
+        enum_spec = ('list', 'exclusions[]', None)
+        scope_key = 'parent'
+        scope_template = "billingAccounts/{}"
+        type_field = 'billing_account_id'


### PR DESCRIPTION
**Changes:**

- Add additional class **CustomScopeTypeInfo** in tools/c7n_gcp/c7n_gcp/query.py which is represent custom parameters logic for URL where do we have more than one (progect_id, zone_id) parameter in URL.
- Add possibility to manage policy validation schema depend on new additional parameters in URL.
- Add the possibility to extend the scope of parameters for the query.

**Motivation:**

There are resources with URLs where do we have more than one path parameter and we must have the possibility to manage them in policy definition.

**Example:**

[Stackdriver Logging resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.exclusions/list)
```python
@resources.register('log-billing-account-exclusion')
class LogBillingAccountExclusion(QueryResourceManager):

    class resource_type(CustomScopeTypeInfo):
        service = 'logging'
        version = 'v2'
        component = 'exclusions'
        enum_spec = ('list', 'exclusions[]', None)
        scope_key = 'parent'
        scope_template = "billingAccounts/{}"
        type_field = 'billing_account_id'
```