### PR TITLE
gcp - [PoC] add support for more than one param in url (option 2)

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -356,6 +356,10 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None, d
     if type_name == 'ec2':
         resource_policy['allOf'][1]['properties']['query'] = {}
 
+    r_type = resource_type.resource_type
+    if getattr(r_type, 'scope', '') in ('billing_account', 'organization', 'folder'):
+        r_type.extended_policy(definitions['policy']['properties'])
+
     r['policy'] = resource_policy
     return {'$ref': '#/definitions/resources/%s/policy' % type_name}
 

--- a/tools/c7n_gcp/c7n_gcp/query.py
+++ b/tools/c7n_gcp/c7n_gcp/query.py
@@ -54,6 +54,10 @@ class ResourceQuery(object):
             if session.get_default_zone():
                 params['zone'] = session.get_default_zone()
 
+        if m.scope in ('billing_account', 'organization', 'folder'):
+            data = resource_manager.data
+            params[m.scope_key] = m.scope_template.format(data[m.type_field])
+
         enum_op, path, extra_args = m.enum_spec
         if extra_args:
             params.update(extra_args)
@@ -199,6 +203,10 @@ class TypeInfo(object):
     get = None
     # for get methods that require the full event payload
     get_requires_event = False
+
+    @staticmethod
+    def extended_policy(schema):
+        return schema
 
 
 ERROR_REASON = jmespath.compile('error.errors[0].reason')

--- a/tools/c7n_gcp/c7n_gcp/resources/logging.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/logging.py
@@ -35,3 +35,21 @@ class LogSink(QueryResourceManager):
             return client.get('get', {
                 'sinkName': 'projects/{project_id}/sinks/{name}'.format(
                     **resource_info)})
+
+
+@resources.register('log-billing-account-exclusion')
+class LogBillingAccountExclusion(QueryResourceManager):
+
+    class resource_type(TypeInfo):
+        service = 'logging'
+        version = 'v2'
+        component = 'exclusions'
+        enum_spec = ('list', 'exclusions[]', None)
+        scope_key = 'parent'
+        scope = 'billing_account'
+        scope_template = "billingAccounts/{}"
+        type_field = 'billing_account_id'
+
+        @classmethod
+        def extended_policy(cls, schema):
+            schema[cls.type_field] = {'type': 'string'}


### PR DESCRIPTION
**Changes:**
- Add new scope types 'billing_account', 'organization' and 'folder'.
- Extend existing schema for policy validation in a case of usage new scope.
- Add parameters extension for a new scope.

**Motivation:**

There are resources with URLs where do we have more than one path parameter and we must have the possibility to manage them in policy definition.

**Example:**

[Stackdriver Logging resource](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.exclusions/list)
```python
@resources.register('log-billing-account-exclusion')
class LogBillingAccountExclusion(QueryResourceManager):

    class resource_type(TypeInfo):
        service = 'logging'
        version = 'v2'
        component = 'exclusions'
        enum_spec = ('list', 'exclusions[]', None)
        scope_key = 'parent'
        scope = 'billing_account'
        scope_template = "billingAccounts/{}"
        type_field = 'billing_account_id'

        @classmethod
        def extended_policy(cls, schema):
            schema[cls.type_field] = {'type': 'string'}
```