### PR TITLE
gcp - [POC] update resource id checking

### DIFF
--- a/tools/c7n_gcp/tests/test_resource.py
+++ b/tools/c7n_gcp/tests/test_resource.py
@@ -21,7 +21,7 @@ class ResourceMetaTest(BaseTest):
     def test_resource_id_meta(self):
         missing = []
         for name, resource in resources.items():
-            if not getattr(resource.resource_type, 'id', None):
+            if not hasattr(resource.resource_type, 'id'):
                 missing.append(name)
 
         if missing:


### PR DESCRIPTION
**Motivation:**
In reason of some resources don't have defined identificator like: "id", "name", etc.. 
Here is a comment from [#3697](https://github.com/cloud-custodian/cloud-custodian/pull/3697/commits/68fa68a678e83e8899a4d597bc00b09b2cfb0ef3#r269557057) pull request:

**Solution:**
I propose to use hasattr method instead of getattr, in this case, we can set id variable in None.
In this case if resource set id as None. We will get Exception.
```python
if not getattr(resource.resource_type, 'id', None):
```

And here we will continue iteration instead of Exception.
```python
if not hasattr(resource.resource_type, 'id'):
```

**Example:**
```python
@resources.register('bq-project')
class BigQueryProject(QueryResourceManager):
    class resource_type(TypeInfo):
        service = 'bigquery'
        version = 'v2'
        component = 'projects'
        enum_spec = ('list', 'projects[]', None)
        scope = 'global'
        id = None
```